### PR TITLE
use reverse instead of explicit URL. this removes the trailing slash

### DIFF
--- a/fugl/main/tests/test_root_view.py
+++ b/fugl/main/tests/test_root_view.py
@@ -25,7 +25,7 @@ class RootViewTestCase(CorvidTestCase):
                                           password=self.admin_password))
         response = self.client.get('/')
         self.assertEqual(response.status_code, 302)
-        self.assertIn('/home/', response.url)
+        self.assertIn('/home', response.url)
 
     def test_other_response_types_500(self):
         self.assertTrue(self.client.login(username=self.admin_user.username,

--- a/fugl/main/views/root.py
+++ b/fugl/main/views/root.py
@@ -1,11 +1,12 @@
+from django.contrib.auth.decorators import login_required
+from django.core.urlresolvers import reverse
 from django.http import HttpResponse
 from django.shortcuts import redirect
-from django.contrib.auth.decorators import login_required
 
 
 @login_required
 def root_controller(request):
     if request.method == 'GET':
-        return redirect('/home/')
+        return redirect(reverse('home'))
     else:
         return HttpResponse(status=500)


### PR DESCRIPTION
closes #4. note my hilarious branch names and cha-cha real smooth
![cha-cha real smooth](http://gif.co/oHgQ.gif)