### PR TITLE
project sharing

### DIFF
--- a/fugl/main/migrations/0019_auto_20160414_1938.py
+++ b/fugl/main/migrations/0019_auto_20160414_1938.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('main', '0018_merge'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ProjectAccess',
+            fields=[
+                ('id', models.AutoField(auto_created=True, verbose_name='ID', primary_key=True, serialize=False)),
+                ('can_edit', models.BooleanField(default=False)),
+                ('project', models.OneToOneField(to='main.Project')),
+                ('user', models.OneToOneField(to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+        migrations.AddField(
+            model_name='project',
+            name='users',
+            field=models.ManyToManyField(related_name='shared_projects', through='main.ProjectAccess', to=settings.AUTH_USER_MODEL),
+        ),
+        migrations.AlterUniqueTogether(
+            name='projectaccess',
+            unique_together=set([('user', 'project')]),
+        ),
+        migrations.AlterIndexTogether(
+            name='projectaccess',
+            index_together=set([('user', 'project')]),
+        ),
+    ]

--- a/fugl/main/models/__init__.py
+++ b/fugl/main/models/__init__.py
@@ -3,6 +3,7 @@ from .page import Page
 from .page_plugin import PagePlugin
 from .post import Post
 from .project import Project
+from .project_access import ProjectAccess
 from .project_plugin import ProjectPlugin
 from .tag import Tag
 from .theme import Theme

--- a/fugl/main/models/project.py
+++ b/fugl/main/models/project.py
@@ -15,6 +15,7 @@ def validate_project(value):
     if not reg.match(value):
         raise ValidationError('Not letters, digits, and -/_.', code='invalid')
 
+
 class Project(models.Model):
     """
     Represents a project: a static website
@@ -31,6 +32,9 @@ class Project(models.Model):
 
     owner = models.ForeignKey(User)
     theme = models.ForeignKey('Theme')
+
+    users = models.ManyToManyField(User, through='ProjectAccess',
+        related_name='shared_projects')
 
     @property
     def project_home_url(self):

--- a/fugl/main/models/project_access.py
+++ b/fugl/main/models/project_access.py
@@ -1,0 +1,15 @@
+from django.db import models
+
+from .project import Project
+from .user import User
+
+
+class ProjectAccess(models.Model):
+
+    class Meta:
+        unique_together = (('user', 'project'),)
+        index_together = (('user', 'project'),)
+
+    user = models.OneToOneField(User, on_delete=models.CASCADE)
+    project = models.OneToOneField(Project, on_delete=models.CASCADE)
+    can_edit = models.BooleanField(default=False)

--- a/fugl/main/templates/account_home.html
+++ b/fugl/main/templates/account_home.html
@@ -27,5 +27,27 @@ Account Home &#8226; Fugl
             </li>
         </ul>
     </div>
+    <div class='panel panel-default'>
+        <div class='panel-heading'>
+            <h2 class='panel-title'>Projects Shared with Me</h2>
+        </div>
+        <ul class='list-group'>
+            {% for access in project_access_list %}
+            {% with project=access.project %}
+            <li class='list-group-item'>
+                <a class='actions' href="{% url 'project_home' owner=project.owner.username title=project.title %}">
+                    <span class='pp-title'>{{ project.title }}</span></a>
+                <span class='badge'>
+                {% if access.can_edit %}
+                Edit
+                {% else %}
+                View
+                {% endif %}
+                </span>
+            </li>
+            {% endwith %}
+            {% endfor %}
+        </ul>
+    </div>
 </div>
 {% endblock %}

--- a/fugl/main/views/user.py
+++ b/fugl/main/views/user.py
@@ -1,7 +1,9 @@
 from django.views.generic import ListView
-from .protected_view import ProtectedViewMixin
-from main.models import Project
 
+from main.models import Project
+from main.models import ProjectAccess
+
+from .protected_view import ProtectedViewMixin
 
 class UserHomeView(ProtectedViewMixin, ListView):
     """View that will list all projects belonging to this User"""
@@ -11,3 +13,14 @@ class UserHomeView(ProtectedViewMixin, ListView):
     def get_queryset(self):
         """Get all projects that belong to this user"""
         return Project.objects.filter(owner=self.request.user)
+
+    def get_context_data(self, *args, **kwargs):
+        context = super(UserHomeView, self).get_context_data(*args, **kwargs)
+        context['project_access_list'] = self.get_project_accesses()
+        return context
+
+    def get_project_accesses(self):
+        user = self.request.user
+        accesses = \
+            ProjectAccess.objects.filter(user=user)
+        return accesses


### PR DESCRIPTION
starting to get project sharing off the ground. making a pr now so we can change up the design early on.

`ProjectAccess` is the intermediate object, `can_edit` defines the permissions on that access. if True, the that user can edit the project; otherwise, that user can only view

things still todo (in later PRs):
- [ ] add ui for sharing a project
- [ ] add ui for editing/deleting "accesses"
- [ ] update other endpoints to allow other users with appropriate access levels to view/edit projects they don't own